### PR TITLE
EPICS 7 fixes

### DIFF
--- a/caSnooper.cc
+++ b/caSnooper.cc
@@ -131,7 +131,7 @@ extern int main(int argc, const char **argv)
     print("delay0=%g wait=%g\n",delay0,wait);
 #endif
     while(delay0 < wait) {
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
 	fileDescriptorManager.process(delay0);
 #else
 	osiTime osiDelay(delay0);
@@ -145,7 +145,7 @@ extern int main(int argc, const char **argv)
 
   // Initialize stat counters
     if(doStats) {
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
       // Start a default timer queue
 	epicsTimerQueueActive &queue = 
 	  epicsTimerQueueActive::allocate(true);
@@ -175,7 +175,7 @@ extern int main(int argc, const char **argv)
     pCAS->enable();
     osiTime start(osiTime::getCurrent());
     while (aitTrue) {
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
 	fileDescriptorManager.process(delay);
 #else
 	osiTime osiDelay(delay);

--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -1,8 +1,36 @@
 # RELEASE.local
+#
+# Read definitions of:
+#	EPICS_SITE_TOP
+#	BASE_MODULE_VERSION
+# from one of the following options
 -include $(TOP)/../../RELEASE_SITE
+-include $(TOP)/RELEASE_SITE
 
-# See if labca is being built in an EPICS extensions release
-ifneq ($(wildcard $(TOP)/../../configure/CONFIG),)
-# Install to TOP of extensions release
-INSTALL_LOCATION_APP := $(abspath $(TOP)/..)
-endif
+# ==========================================================
+# Define the version strings for all needed modules
+# ==========================================================
+PCAS_MODULE_VERSION		= R4.13.2-0.3.1
+
+# ==========================================================
+# External Support module path definitions
+#
+# If any of these macros expand to a path which
+# contains an "include" directory, that directory will be
+# included in the compiler include path.
+#
+# If any of these macros expand to a path which
+# contains a "lib/<arch>" directory, that directory will be
+# included in the compiler link path for that architecture.
+#
+# If your build fails, look for these paths in your build output
+# ==========================================================
+PCAS            = $(EPICS_MODULES)/pcas/$(PCAS_MODULE_VERSION)
+
+
+# Set EPICS_BASE last so it appears last in the DB, DBD, INCLUDE, and LIB search paths
+EPICS_BASE = $(EPICS_SITE_TOP)/base/$(BASE_MODULE_VERSION)
+
+# Check for invalid or undefined EPICS_BASE
+-include $(TOP)/../../EPICS_BASE.check
+

--- a/snoopServer.cc
+++ b/snoopServer.cc
@@ -25,7 +25,7 @@
 
 #define HOST_NAMESIZE 256
 
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
 #include <osiSock.h>
 #else
 #include <bsdSocketResource.h>
@@ -74,7 +74,7 @@ snoopServer::snoopServer(char *prefixIn, char *individualNameIn,
     individualCount(0)
 {
   // Initialize the PV list
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
   // No longer required
 #else
     pvList.init(2048u);
@@ -89,7 +89,7 @@ snoopServer::snoopServer(char *prefixIn, char *individualNameIn,
     requestCount=0u;
 
   // Set the select mask to everything supported
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
     selectMask=(alarmEventMask()|valueEventMask()|logEventMask());
 #else
     selectMask=(alarmEventMask|valueEventMask|logEventMask);
@@ -100,7 +100,7 @@ snoopServer::snoopServer(char *prefixIn, char *individualNameIn,
 snoopServer::~snoopServer(void)
 {
   // Clear the pvList
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
     pvList.traverse(&dataNode::destroy);
 #else
     pvList.destroyAllEntries();
@@ -117,7 +117,7 @@ void snoopServer::clearStat(int type)
 // This function is called by Base 3.13 and earlier
 pvExistReturn snoopServer::pvExistTest(const casCtx& ctx, const char *pvName)
 {
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
   // Should not get here
     return pverDoesNotExistHere;
 #else
@@ -510,7 +510,7 @@ void snoopServer::report(void)
 void snoopServer::reset(void)
 {
   // Clear the pvList
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
     pvList.traverse(&dataNode::destroy);
 #else
     pvList.destroyAllEntries();
@@ -776,7 +776,7 @@ snoopData &snoopData::operator=(const snoopData &snoopDataIn)
 ////////////////////////////////////////////////////////////////////////
 
 // snoopRateStatsTimer::expire /////////////////////////////////////////
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
 epicsTimerNotify::expireStatus
 snoopRateStatsTimer::expire(const epicsTime &curTime)
 {

--- a/snoopServer.h
+++ b/snoopServer.h
@@ -51,7 +51,7 @@
 #include "snoopStat.h"
 #include "epicsVersion.h"
 
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
 #include "epicsTimer.h"
 #define osiTime epicsTime
 #else
@@ -86,7 +86,7 @@ typedef struct _snoopServerStats
     short precision;
 } snoopServerStats;
 
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
 class snoopRateStatsTimer : public epicsTimerNotify
 {
   public:

--- a/snoopStat.h
+++ b/snoopStat.h
@@ -17,7 +17,7 @@
 
 #include "epicsVersion.h"
 
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
 #define WRITE_CONST const
 #else
 #define WRITE_CONST

--- a/ut.cc
+++ b/ut.cc
@@ -116,7 +116,7 @@ struct timespec *timeSpec(void)
     static struct timespec ts;
     osiTime osit(osiTime::getCurrent());
   // EPICS is 20 years ahead of its time
-#if EPICS_REVISION > 13
+#if (EPICS_REVISION > 13 && EPICS_VERSION == 3) || EPICS_VERSION >= 7
     ts=osit;
 #else
     ts.tv_sec=(time_t)osit.getSecTruncToLong()-631152000ul;


### PR DESCRIPTION
* Fixed EPICS_VERSION/EPICS_REVISION checks for EPICS 7.0+
* Build against pcas R4.13.2-0.3.1

The next tag version should be R2.1.2.3-0.2.0